### PR TITLE
chore: apply GitHub Actions best practices to workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: write
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Background

Apply GitHub Actions best practices org-wide. This PR brings `SwiftMilkdown` workflow in line with the org standard.

## Changes

### `release.yml`

- Add `defaults.run.shell: bash` at workflow level

### Intentionally NOT applied: `persist-credentials: false`

The release workflow runs `git push origin "${BRANCH_NAME}"` and `git push origin "${VERSION}"` after checkout. Setting `persist-credentials: false` would break these pushes because the checkout-configured token would no longer be present in the git config. Keeping the default behavior here is correct unless the workflow is restructured to authenticate pushes explicitly.

### Already compliant (no change)

- `permissions: contents: write` is scoped to what release creation needs
- All third-party actions are already SHA-pinned

## Why

- `defaults.run.shell: bash`: ensures consistent shell behavior across runners
