### PR TITLE
chore: group milkdown packages in a single Renovate PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,4 +3,15 @@
   extends: [
     'github>LabeeHive/renovate-config:default.json5',
   ],
+
+  // Milkdown packages must be bumped together: they share the private-field
+  // `Ctx` type from @milkdown/ctx, so bumping only one package leaves a
+  // mismatched version of @milkdown/ctx in node_modules and breaks
+  // `pnpm run typecheck`.
+  packageRules: [
+    {
+      groupName: 'milkdown',
+      matchSourceUrls: ['https://github.com/Milkdown/milkdown'],
+    },
+  ],
 }


### PR DESCRIPTION
## Summary
- Adds a `packageRules` entry to `.github/renovate.json5` that groups all `@milkdown/*` packages (matched via `matchSourceUrls` on the Milkdown/milkdown repo, https://github.com/Milkdown/milkdown) into a single Renovate PR named `milkdown`.

## Why
- Milkdown packages (`@milkdown/kit`, `@milkdown/plugin-emoji`, `@milkdown/plugin-prism`, `@milkdown/theme-nord`, `@milkdown/prose`, ...) all depend on `@milkdown/ctx`, whose `Ctx` type uses a JS private field.
- Renovate currently opens one PR per package. Bumping only one package leaves other Milkdown packages resolving an older `@milkdown/ctx` in `node_modules`, so TypeScript sees two structurally-identical-but-nominally-different `Ctx` types and `pnpm run typecheck` fails.
- Current open PRs #81, #82, #83, #85 (kit, plugin-emoji, plugin-prism, theme-nord to 7.21.3) all fail CI for exactly this reason.
- Grouping the packages means Renovate will bump them together in one PR going forward, keeping `@milkdown/ctx` versions consistent.

## Test plan
- [ ] After merge, close/rebase the existing individual milkdown PRs (#81, #82, #83, #85) and let Renovate regroup them into a single PR on its next run.
- [ ] Confirm the resulting grouped PR passes `pnpm run typecheck` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
